### PR TITLE
Fixed an error by duplicated variable name.

### DIFF
--- a/preprocessing/CCDRawProcessing.m
+++ b/preprocessing/CCDRawProcessing.m
@@ -65,8 +65,8 @@ for i_file  = 1:  length(dirents)
     save(image_filename,'im');
     imwrite(image, fullfile(output_folder, num2str(i_file, '%06d.png')));
 
-    illuminants_filename = fullfile(output_folder, num2str(i_file, '%06d_gt.mat'));
+    gt_illuminants_filename = fullfile(output_folder, num2str(i_file, '%06d_gt.mat'));
     gt = illuminant;
-    save(illuminants_filename, 'gt');
+    save(gt_illuminants_filename, 'gt');
 end
 


### PR DESCRIPTION
There is an error by duplicated variable name at  ``Line 71`` and ``Line 73`` in ``preprocessing/CCDRawProcessing.m``. The variable ``illuminants_filename`` has to indicate the file ``real_illum_568..mat`` after an iteration ended in ``for`` loop from ``Line 40``.